### PR TITLE
Fix fuzzy matching for non-word characters

### DIFF
--- a/src/main/webapp/js/keyboard-shortcuts.js
+++ b/src/main/webapp/js/keyboard-shortcuts.js
@@ -52,7 +52,7 @@ if (ks_enabled) {
 
   function ks_is_fuzzy_match(name, pattern) {
     if (ks_cached_pattern.pattern != pattern) {
-      ks_cached_pattern.regex = new RegExp(pattern.replace(/\W/, "").split('').join('\\w*'), 'i');
+      ks_cached_pattern.regex = new RegExp(pattern.replace(/\W/, "").split('').join('\.*'), 'i');
       ks_cached_pattern.pattern = pattern;
     }
     return name.match(ks_cached_pattern.regex);


### PR DESCRIPTION
When doing fuzzy matching, non-word characters in the pattern are
ignored and the regex that is constructed will never match any non-
word caracters.

Fix it by matching any character, not just word caracters in the
pattern.
